### PR TITLE
Restructuring SI_Toolkit (+ small corrections)

### DIFF
--- a/Controllers/controller_gradient_tf.py
+++ b/Controllers/controller_gradient_tf.py
@@ -3,7 +3,7 @@ from importlib import import_module
 import numpy as np
 import tensorflow as tf
 from others.globals_and_utils import create_rng
-from SI_Toolkit.TF.TF_Functions.Compile import Compile
+from SI_Toolkit.Functions.TF.Compile import Compile
 
 from Control_Toolkit.Controllers import template_controller
 

--- a/others/globals_and_utils.py
+++ b/others/globals_and_utils.py
@@ -11,7 +11,7 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"  # all TF messages
 
 import tensorflow as tf
 from numpy.random import SFC64, Generator
-from SI_Toolkit.TF.TF_Functions.Compile import Compile
+from SI_Toolkit.Functions.TF.Compile import Compile
 
 LOGGING_LEVEL = logging.INFO
 


### PR DESCRIPTION
Goal: easy switch between training in TF or Pytorch.
Needed for: DeltaRNN
Done:
Big part of TF functions rewritten/moved to serve also for Pytorch training while removing duplications. Still potential to remove duplicate code in Dataset.py.
Additionaly small corrections to controllers:
removing controller_nn_as_mpc_tf.py (duplication of controller_neural_imitator_tf.py)
Correct import of lqr as auxiliary controller to mppi
Deleting unused imports done semiautomatically, maybe unnecessarily much.